### PR TITLE
Refactored DSL to lose dependency on bpf program

### DIFF
--- a/bpfbox/utils.py
+++ b/bpfbox/utils.py
@@ -27,6 +27,10 @@ import sys
 import itertools
 import signal
 import subprocess
+from collections import defaultdict
+
+
+profile_key_to_exe = defaultdict(lambda: '[unknown]')
 
 
 def get_inode_and_device(path, follow_symlink=True):
@@ -43,7 +47,9 @@ def calculate_profile_key(path, follow_symlink=True):
     logic as bpf_program.c
     """
     st_ino, st_dev = get_inode_and_device(path, follow_symlink)
-    return st_ino | (st_dev << 32)
+    profile_key = st_ino | (st_dev << 32)
+    profile_key_to_exe[profile_key] = path
+    return profile_key
 
 
 def check_root():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from bpfbox.argument_parser import parse_args
 from bpfbox.bpf_program import BPFProgram
 from bpfbox.logger import BPFBoxLoggerClass
 from bpfbox import defs
+from bpfbox.utils import profile_key_to_exe
 
 AUDIT = BPFBoxLoggerClass.AUDIT
 DEBUG = logging.DEBUG
@@ -34,4 +35,4 @@ def bpf_program(caplog):
     b.bpf['ipc_policy'].clear()
     # IMPORTANT NOTE: remember to put new maps here
 
-    b.profile_key_to_exe.clear()
+    profile_key_to_exe.clear()

--- a/tests/fs/test_fs_enforcement.py
+++ b/tests/fs/test_fs_enforcement.py
@@ -34,6 +34,7 @@ from bpfbox.logger import BPFBoxLoggerClass
 from bpfbox.utils import get_inode_and_device, which
 from bpfbox.flags import BPFBOX_ACTION, FS_ACCESS
 from bpfbox import defs
+from bpfbox.libbpfbox import Commands
 
 DRIVER_PATH = os.path.join(defs.project_path, 'tests/driver')
 OPEN_PATH = os.path.join(DRIVER_PATH, 'open')
@@ -50,30 +51,30 @@ def setup_testdir():
 
 
 def test_fs_implicit_taint(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, True)
+    Commands.add_profile(OPEN_PATH, True)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call(OPEN_PATH)
 
 
 def test_fs_no_taint(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
+    Commands.add_profile(OPEN_PATH, False)
 
     subprocess.check_call(OPEN_PATH)
 
 
 def test_fs_taint(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'simple-read'])
 
 
 def test_fs_allow_read_only(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ)
 
     subprocess.check_call([OPEN_PATH, 'simple-read'])
 
@@ -85,9 +86,9 @@ def test_fs_allow_read_only(bpf_program: BPFProgram, caplog, setup_testdir):
 
 
 def test_fs_allow_read_write(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ | FS_ACCESS.WRITE)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ | FS_ACCESS.WRITE)
 
     subprocess.check_call([OPEN_PATH, 'simple-read'])
 
@@ -97,9 +98,9 @@ def test_fs_allow_read_write(bpf_program: BPFProgram, caplog, setup_testdir):
 
 
 def test_fs_allow_append_only(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.APPEND)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.APPEND)
 
     subprocess.check_call([OPEN_PATH, 'simple-write-append'])
 
@@ -108,9 +109,9 @@ def test_fs_allow_append_only(bpf_program: BPFProgram, caplog, setup_testdir):
 
 
 def test_fs_allow_write_only(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.WRITE)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.WRITE)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'simple-write-append'])
@@ -119,9 +120,9 @@ def test_fs_allow_write_only(bpf_program: BPFProgram, caplog, setup_testdir):
 
 
 def test_fs_allow_write_and_append(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.WRITE | FS_ACCESS.APPEND)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.WRITE | FS_ACCESS.APPEND)
 
     subprocess.check_call([OPEN_PATH, 'simple-write-append'])
 
@@ -129,12 +130,12 @@ def test_fs_allow_write_and_append(bpf_program: BPFProgram, caplog, setup_testdi
 
 
 def test_fs_complex_policy(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ | FS_ACCESS.WRITE)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/b', FS_ACCESS.APPEND)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/c', FS_ACCESS.READ)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/d', FS_ACCESS.EXEC)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ | FS_ACCESS.WRITE)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/b', FS_ACCESS.APPEND)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/c', FS_ACCESS.READ)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/d', FS_ACCESS.EXEC)
 
     subprocess.check_call([OPEN_PATH, 'complex'])
 
@@ -145,18 +146,18 @@ def test_fs_complex_policy(bpf_program: BPFProgram, caplog, setup_testdir):
 
 
 def test_parent_child(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'parent-child'])
 
 
 def test_procfs(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/proc', FS_ACCESS.EXEC)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/proc', FS_ACCESS.EXEC)
 
     subprocess.check_call([OPEN_PATH, 'proc-self'])
 
@@ -167,10 +168,10 @@ def test_procfs(bpf_program: BPFProgram, caplog, setup_testdir):
 @pytest.mark.skipif(not which('sleep'), reason='sleep not found on system')
 def test_procfs_other_process(bpf_program: BPFProgram, caplog, setup_testdir):
     sleep_path = which('sleep')
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/proc', FS_ACCESS.EXEC)
-    bpf_program.add_procfs_rule(OPEN_PATH, sleep_path, FS_ACCESS.READ | FS_ACCESS.EXEC)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/proc', FS_ACCESS.EXEC)
+    Commands.add_procfs_rule(OPEN_PATH, sleep_path, FS_ACCESS.READ | FS_ACCESS.EXEC)
 
     subprocess.check_call([OPEN_PATH, 'proc-self'])
 
@@ -181,9 +182,9 @@ def test_procfs_other_process(bpf_program: BPFProgram, caplog, setup_testdir):
 @pytest.mark.skipif(not which('sleep'), reason='sleep not found on system')
 def test_procfs_other_process_not_allowed(bpf_program: BPFProgram, caplog, setup_testdir):
     sleep_path = which('sleep')
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/proc', FS_ACCESS.EXEC)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/proc', FS_ACCESS.EXEC)
 
     subprocess.check_call([OPEN_PATH, 'proc-self'])
 
@@ -194,60 +195,60 @@ def test_procfs_other_process_not_allowed(bpf_program: BPFProgram, caplog, setup
 
 
 def test_chown_allowed(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ | FS_ACCESS.SETATTR)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ | FS_ACCESS.SETATTR)
 
     subprocess.check_call([OPEN_PATH, 'chown-a'])
 
 
 def test_chown_disallowed(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'chown-a'])
 
 
 def test_create_file_allowed(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
 
     subprocess.check_call([OPEN_PATH, 'create-file'])
 
 
 def test_create_file_disallowed(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.READ | FS_ACCESS.EXEC)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.READ | FS_ACCESS.EXEC)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'create-file'])
 
 
 def test_create_dir_allowed(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
 
     subprocess.check_call([OPEN_PATH, 'create-dir'])
 
 
 def test_create_dir_no_write(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.EXEC)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.EXEC)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'create-dir'])
 
 
 def test_create_dir_no_exec(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'create-dir'])
@@ -255,20 +256,20 @@ def test_create_dir_no_exec(bpf_program: BPFProgram, caplog, setup_testdir):
 
 def test_rmdir_allowed(bpf_program: BPFProgram, caplog, setup_testdir):
     os.mkdir('/tmp/bpfbox/e')
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/e', FS_ACCESS.RM)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/e', FS_ACCESS.RM)
 
     subprocess.check_call([OPEN_PATH, 'rmdir'])
 
 
 def test_rmdir_no_write(bpf_program: BPFProgram, caplog, setup_testdir):
     os.mkdir('/tmp/bpfbox/e')
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.EXEC)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/e', FS_ACCESS.RM)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.EXEC)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/e', FS_ACCESS.RM)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'rmdir'])
@@ -276,9 +277,9 @@ def test_rmdir_no_write(bpf_program: BPFProgram, caplog, setup_testdir):
 
 def test_rmdir_no_rm(bpf_program: BPFProgram, caplog, setup_testdir):
     os.mkdir('/tmp/bpfbox/e')
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'rmdir'])
@@ -286,20 +287,20 @@ def test_rmdir_no_rm(bpf_program: BPFProgram, caplog, setup_testdir):
 
 def test_unlink_allowed(bpf_program: BPFProgram, caplog, setup_testdir):
     open('/tmp/bpfbox/e', 'a').close()
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/e', FS_ACCESS.RM)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/e', FS_ACCESS.RM)
 
     subprocess.check_call([OPEN_PATH, 'unlink'])
 
 
 def test_unlink_no_write(bpf_program: BPFProgram, caplog, setup_testdir):
     open('/tmp/bpfbox/e', 'a').close()
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.EXEC)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/e', FS_ACCESS.RM)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.EXEC)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/e', FS_ACCESS.RM)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'unlink'])
@@ -307,36 +308,36 @@ def test_unlink_no_write(bpf_program: BPFProgram, caplog, setup_testdir):
 
 def test_unlink_no_rm(bpf_program: BPFProgram, caplog, setup_testdir):
     open('/tmp/bpfbox/e', 'a').close()
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'unlink'])
 
 
 def test_link_allowed(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.ADD_LINK)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.ADD_LINK)
 
     subprocess.check_call([OPEN_PATH, 'link'])
 
 
 def test_link_no_write(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.ADD_LINK)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.ADD_LINK)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'link'])
 
 
 def test_link_no_link(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'link'])
@@ -344,21 +345,21 @@ def test_link_no_link(bpf_program: BPFProgram, caplog, setup_testdir):
 
 def test_rename_allowed(bpf_program: BPFProgram, caplog, setup_testdir):
     os.mkdir('/tmp/bpfbox/new_dir')
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/new_dir', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.RM)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/new_dir', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.RM)
 
     subprocess.check_call([OPEN_PATH, 'rename'])
 
 
 def test_rename_no_olddir_write(bpf_program: BPFProgram, caplog, setup_testdir):
     os.mkdir('/tmp/bpfbox/new_dir')
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/new_dir', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.RM)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/new_dir', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.RM)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'rename'])
@@ -366,11 +367,11 @@ def test_rename_no_olddir_write(bpf_program: BPFProgram, caplog, setup_testdir):
 
 def test_rename_no_newdir_write(bpf_program: BPFProgram, caplog, setup_testdir):
     os.mkdir('/tmp/bpfbox/new_dir')
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/new_dir', FS_ACCESS.EXEC)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.RM)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/new_dir', FS_ACCESS.EXEC)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.RM)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'rename'])
@@ -378,65 +379,65 @@ def test_rename_no_newdir_write(bpf_program: BPFProgram, caplog, setup_testdir):
 
 def test_rename_no_old_rm(bpf_program: BPFProgram, caplog, setup_testdir):
     os.mkdir('/tmp/bpfbox/new_dir')
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/new_dir', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/new_dir', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'rename'])
 
 
 def test_symlink_allowed(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE | FS_ACCESS.EXEC)
 
     subprocess.check_call([OPEN_PATH, 'symlink'])
 
 
 def test_symlink_disallowed(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.READ | FS_ACCESS.EXEC)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.READ | FS_ACCESS.EXEC)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'symlink'])
 
 
 def test_malicious_symlink_cannot_write_dir(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'malicious-symlink-read'])
 
 
 def test_malicious_symlink_cannot_add_link(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'malicious-symlink-read'])
 
 
 def test_malicious_symlink_cannot_read_original(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.ADD_LINK)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.ADD_LINK)
 
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call([OPEN_PATH, 'malicious-symlink-read'])
 
 
 def test_non_malicious_symlink_can_read_original(bpf_program: BPFProgram, caplog, setup_testdir):
-    bpf_program.add_profile(OPEN_PATH, False)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.ADD_LINK)
-    bpf_program.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ)
+    Commands.add_profile(OPEN_PATH, False)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ, BPFBOX_ACTION.TAINT)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox', FS_ACCESS.WRITE)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.ADD_LINK)
+    Commands.add_fs_rule(OPEN_PATH, '/tmp/bpfbox/a', FS_ACCESS.READ)
 
     subprocess.check_call([OPEN_PATH, 'malicious-symlink-read'])
 
@@ -444,28 +445,28 @@ def test_non_malicious_symlink_can_read_original(bpf_program: BPFProgram, caplog
 @pytest.mark.skipif(not which('exa'), reason='exa not found on system')
 def test_exa(bpf_program: BPFProgram, caplog, setup_testdir):
     exa = which('exa')
-    bpf_program.add_profile(exa, True)
-    bpf_program.add_fs_rule(exa, "/etc/ld.so.cache", FS_ACCESS.READ | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, "/usr/lib/libz.so.1", FS_ACCESS.READ | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, "/usr/lib/libdl.so.2", FS_ACCESS.READ | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, "/usr/lib/librt.so.1", FS_ACCESS.READ | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, "/usr/lib/libpthread.so.0", FS_ACCESS.READ | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, "/usr/lib/libgcc_s.so.1", FS_ACCESS.READ | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, "/usr/lib/libc.so.6", FS_ACCESS.READ | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, "/usr/lib/perl5/5.30/core_perl/CORE/dquote_inline.h", FS_ACCESS.EXEC | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, "/usr/lib/libnss_files-2.31.so", FS_ACCESS.EXEC | FS_ACCESS.READ | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, "/etc/localtime", FS_ACCESS.READ | FS_ACCESS.EXEC | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, "/usr/lib/locale/locale-archive", FS_ACCESS.READ | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, "/etc/nsswitch.conf", FS_ACCESS.READ | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, "/etc/passwd", FS_ACCESS.READ | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, "/var", FS_ACCESS.EXEC | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, "/run/nscd", FS_ACCESS.EXEC | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, '/proc', FS_ACCESS.EXEC | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, '/tmp/bpfbox', FS_ACCESS.READ | FS_ACCESS.EXEC | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, '/tmp/bpfbox/a', FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, '/tmp/bpfbox/b', FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, '/tmp/bpfbox/c', FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(exa, '/tmp/bpfbox/d', FS_ACCESS.GETATTR)
+    Commands.add_profile(exa, True)
+    Commands.add_fs_rule(exa, "/etc/ld.so.cache", FS_ACCESS.READ | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, "/usr/lib/libz.so.1", FS_ACCESS.READ | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, "/usr/lib/libdl.so.2", FS_ACCESS.READ | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, "/usr/lib/librt.so.1", FS_ACCESS.READ | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, "/usr/lib/libpthread.so.0", FS_ACCESS.READ | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, "/usr/lib/libgcc_s.so.1", FS_ACCESS.READ | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, "/usr/lib/libc.so.6", FS_ACCESS.READ | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, "/usr/lib/perl5/5.30/core_perl/CORE/dquote_inline.h", FS_ACCESS.EXEC | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, "/usr/lib/libnss_files-2.31.so", FS_ACCESS.EXEC | FS_ACCESS.READ | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, "/etc/localtime", FS_ACCESS.READ | FS_ACCESS.EXEC | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, "/usr/lib/locale/locale-archive", FS_ACCESS.READ | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, "/etc/nsswitch.conf", FS_ACCESS.READ | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, "/etc/passwd", FS_ACCESS.READ | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, "/var", FS_ACCESS.EXEC | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, "/run/nscd", FS_ACCESS.EXEC | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, '/proc', FS_ACCESS.EXEC | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, '/tmp/bpfbox', FS_ACCESS.READ | FS_ACCESS.EXEC | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, '/tmp/bpfbox/a', FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, '/tmp/bpfbox/b', FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, '/tmp/bpfbox/c', FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(exa, '/tmp/bpfbox/d', FS_ACCESS.GETATTR)
 
     out = subprocess.check_output([exa, '/tmp/bpfbox']).decode('utf-8')
     assert out.strip() == '\n'.join(sorted(os.listdir('/tmp/bpfbox')))
@@ -473,17 +474,17 @@ def test_exa(bpf_program: BPFProgram, caplog, setup_testdir):
 @pytest.mark.skipif(not which('ls'), reason='ls not found on system')
 def test_ls(bpf_program: BPFProgram, caplog, setup_testdir):
     ls = which('ls')
-    bpf_program.add_profile(ls, True)
-    bpf_program.add_fs_rule(ls, "/etc/ld.so.cache", FS_ACCESS.READ | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(ls, "/usr/lib/libcap.so.2", FS_ACCESS.READ | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(ls, "/usr/lib/libc.so.6", FS_ACCESS.READ | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(ls, "/usr/lib/locale/locale-archive", FS_ACCESS.READ | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(ls, '/proc', FS_ACCESS.EXEC)
-    bpf_program.add_fs_rule(ls, '/tmp/bpfbox', FS_ACCESS.READ | FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(ls, '/tmp/bpfbox/a', FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(ls, '/tmp/bpfbox/b', FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(ls, '/tmp/bpfbox/c', FS_ACCESS.GETATTR)
-    bpf_program.add_fs_rule(ls, '/tmp/bpfbox/d', FS_ACCESS.GETATTR)
+    Commands.add_profile(ls, True)
+    Commands.add_fs_rule(ls, "/etc/ld.so.cache", FS_ACCESS.READ | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(ls, "/usr/lib/libcap.so.2", FS_ACCESS.READ | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(ls, "/usr/lib/libc.so.6", FS_ACCESS.READ | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(ls, "/usr/lib/locale/locale-archive", FS_ACCESS.READ | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(ls, '/proc', FS_ACCESS.EXEC)
+    Commands.add_fs_rule(ls, '/tmp/bpfbox', FS_ACCESS.READ | FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(ls, '/tmp/bpfbox/a', FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(ls, '/tmp/bpfbox/b', FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(ls, '/tmp/bpfbox/c', FS_ACCESS.GETATTR)
+    Commands.add_fs_rule(ls, '/tmp/bpfbox/d', FS_ACCESS.GETATTR)
 
     out = subprocess.check_output([ls, '/tmp/bpfbox']).decode('utf-8')
     assert out.strip() == '\n'.join(sorted(os.listdir('/tmp/bpfbox')))

--- a/tests/ipc/test_ipc_enforcement.py
+++ b/tests/ipc/test_ipc_enforcement.py
@@ -34,73 +34,74 @@ from bpfbox.logger import BPFBoxLoggerClass
 from bpfbox.utils import get_inode_and_device, which
 from bpfbox.flags import BPFBOX_ACTION, IPC_ACCESS
 from bpfbox import defs
+from bpfbox.libbpfbox import Commands
 
 DRIVER_PATH = os.path.join(defs.project_path, 'tests/driver')
 IPC_PATH = os.path.join(DRIVER_PATH, 'ipc')
 
 def test_ipc_no_taint(bpf_program: BPFProgram, caplog):
-    bpf_program.add_profile(IPC_PATH, False)
+    Commands.add_profile(IPC_PATH, False)
 
     rc = subprocess.Popen([IPC_PATH, 'kill-self']).wait()
     assert rc == -signal.SIGKILL
 
 def test_ipc_kill_self(bpf_program: BPFProgram, caplog):
-    bpf_program.add_profile(IPC_PATH, False)
-    bpf_program.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
+    Commands.add_profile(IPC_PATH, False)
+    Commands.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
 
     rc = subprocess.Popen([IPC_PATH, 'kill-self']).wait()
     assert rc == 1
 
-    bpf_program.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGKILL)
+    Commands.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGKILL)
     rc = subprocess.Popen([IPC_PATH, 'kill-self']).wait()
     assert rc == -signal.SIGKILL
 
 @pytest.mark.skipif(not which('sleep'), reason='sleep not found on system')
 def test_ipc_kill_target(bpf_program: BPFProgram, caplog):
     sleep_path = which('sleep')
-    bpf_program.add_profile(IPC_PATH, False)
-    bpf_program.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
+    Commands.add_profile(IPC_PATH, False)
+    Commands.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
 
     target_pid = subprocess.Popen([sleep_path, '10']).pid
     rc = subprocess.Popen([IPC_PATH, 'kill-target', str(target_pid)]).wait()
     assert rc == 1
 
-    bpf_program.add_ipc_rule(IPC_PATH, sleep_path, IPC_ACCESS.SIGKILL)
+    Commands.add_ipc_rule(IPC_PATH, sleep_path, IPC_ACCESS.SIGKILL)
     target_pid = subprocess.Popen([sleep_path, '10']).pid
     rc = subprocess.Popen([IPC_PATH, 'kill-target', str(target_pid)]).wait()
     assert rc == 0
 
 
 def test_ipc_check_self(bpf_program: BPFProgram, caplog):
-    bpf_program.add_profile(IPC_PATH, False)
-    bpf_program.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
+    Commands.add_profile(IPC_PATH, False)
+    Commands.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
 
     rc = subprocess.Popen([IPC_PATH, 'check-self']).wait()
     assert rc == 1
 
-    bpf_program.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK)
+    Commands.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK)
     rc = subprocess.Popen([IPC_PATH, 'check-self']).wait()
     assert rc == 0
 
 @pytest.mark.skipif(not which('sleep'), reason='sleep not found on system')
 def test_ipc_check_target(bpf_program: BPFProgram, caplog):
     sleep_path = which('sleep')
-    bpf_program.add_profile(IPC_PATH, False)
-    bpf_program.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
+    Commands.add_profile(IPC_PATH, False)
+    Commands.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
 
     target_pid = subprocess.Popen([sleep_path, '10']).pid
     rc = subprocess.Popen([IPC_PATH, 'check-target', str(target_pid)]).wait()
     assert rc == 1
 
-    bpf_program.add_ipc_rule(IPC_PATH, sleep_path, IPC_ACCESS.SIGCHECK)
+    Commands.add_ipc_rule(IPC_PATH, sleep_path, IPC_ACCESS.SIGCHECK)
     target_pid = subprocess.Popen([sleep_path, '10']).pid
     rc = subprocess.Popen([IPC_PATH, 'check-target', str(target_pid)]).wait()
     assert rc == 0
 
 
 def test_ipc_stop_self(bpf_program: BPFProgram, caplog):
-    bpf_program.add_profile(IPC_PATH, False)
-    bpf_program.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
+    Commands.add_profile(IPC_PATH, False)
+    Commands.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
 
     p = subprocess.Popen([IPC_PATH, 'stop-self'])
     try:
@@ -110,7 +111,7 @@ def test_ipc_stop_self(bpf_program: BPFProgram, caplog):
         rc = p.wait(1)
     assert rc == 1
 
-    bpf_program.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGSTOP)
+    Commands.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGSTOP)
     p = subprocess.Popen([IPC_PATH, 'stop-self'])
     try:
         rc = p.wait(1)
@@ -122,8 +123,8 @@ def test_ipc_stop_self(bpf_program: BPFProgram, caplog):
 @pytest.mark.skipif(not which('sleep'), reason='sleep not found on system')
 def test_ipc_stop_target(bpf_program: BPFProgram, caplog):
     sleep_path = which('sleep')
-    bpf_program.add_profile(IPC_PATH, False)
-    bpf_program.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
+    Commands.add_profile(IPC_PATH, False)
+    Commands.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
 
     target_pid = subprocess.Popen([sleep_path, '10']).pid
     rc = subprocess.Popen([IPC_PATH, 'stop-target', str(target_pid)]).wait()
@@ -133,7 +134,7 @@ def test_ipc_stop_target(bpf_program: BPFProgram, caplog):
         pass
     assert rc == 1
 
-    bpf_program.add_ipc_rule(IPC_PATH, sleep_path, IPC_ACCESS.SIGSTOP)
+    Commands.add_ipc_rule(IPC_PATH, sleep_path, IPC_ACCESS.SIGSTOP)
     target_pid = subprocess.Popen([sleep_path, '10']).pid
     rc = subprocess.Popen([IPC_PATH, 'stop-target', str(target_pid)]).wait()
     try:
@@ -144,54 +145,54 @@ def test_ipc_stop_target(bpf_program: BPFProgram, caplog):
 
 
 def test_ipc_chld_self(bpf_program: BPFProgram, caplog):
-    bpf_program.add_profile(IPC_PATH, False)
-    bpf_program.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
+    Commands.add_profile(IPC_PATH, False)
+    Commands.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
 
     rc = subprocess.Popen([IPC_PATH, 'chld-self']).wait()
     assert rc == 1
 
-    bpf_program.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHLD)
+    Commands.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHLD)
     rc = subprocess.Popen([IPC_PATH, 'chld-self']).wait()
     assert rc == 0
 
 @pytest.mark.skipif(not which('sleep'), reason='sleep not found on system')
 def test_ipc_chld_target(bpf_program: BPFProgram, caplog):
     sleep_path = which('sleep')
-    bpf_program.add_profile(IPC_PATH, False)
-    bpf_program.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
+    Commands.add_profile(IPC_PATH, False)
+    Commands.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
 
     target_pid = subprocess.Popen([sleep_path, '10']).pid
     rc = subprocess.Popen([IPC_PATH, 'chld-target', str(target_pid)]).wait()
     assert rc == 1
 
-    bpf_program.add_ipc_rule(IPC_PATH, sleep_path, IPC_ACCESS.SIGCHLD)
+    Commands.add_ipc_rule(IPC_PATH, sleep_path, IPC_ACCESS.SIGCHLD)
     target_pid = subprocess.Popen([sleep_path, '10']).pid
     rc = subprocess.Popen([IPC_PATH, 'chld-target', str(target_pid)]).wait()
     assert rc == 0
 
 
 def test_ipc_usr1_self(bpf_program: BPFProgram, caplog):
-    bpf_program.add_profile(IPC_PATH, False)
-    bpf_program.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
+    Commands.add_profile(IPC_PATH, False)
+    Commands.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
 
     rc = subprocess.Popen([IPC_PATH, 'usr1-self']).wait()
     assert rc == 1
 
-    bpf_program.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGMISC)
+    Commands.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGMISC)
     rc = subprocess.Popen([IPC_PATH, 'usr1-self']).wait()
     assert rc == -signal.SIGUSR1
 
 @pytest.mark.skipif(not which('sleep'), reason='sleep not found on system')
 def test_ipc_usr1_target(bpf_program: BPFProgram, caplog):
     sleep_path = which('sleep')
-    bpf_program.add_profile(IPC_PATH, False)
-    bpf_program.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
+    Commands.add_profile(IPC_PATH, False)
+    Commands.add_ipc_rule(IPC_PATH, IPC_PATH, IPC_ACCESS.SIGCHECK, BPFBOX_ACTION.TAINT)
 
     target_pid = subprocess.Popen([sleep_path, '10']).pid
     rc = subprocess.Popen([IPC_PATH, 'usr1-target', str(target_pid)]).wait()
     assert rc == 1
 
-    bpf_program.add_ipc_rule(IPC_PATH, sleep_path, IPC_ACCESS.SIGMISC)
+    Commands.add_ipc_rule(IPC_PATH, sleep_path, IPC_ACCESS.SIGMISC)
     target_pid = subprocess.Popen([sleep_path, '10']).pid
     rc = subprocess.Popen([IPC_PATH, 'usr1-target', str(target_pid)]).wait()
     assert rc == 0

--- a/tests/policy/test_policy_dsl_parser.py
+++ b/tests/policy/test_policy_dsl_parser.py
@@ -25,7 +25,7 @@ from pyparsing import ParseException, Group
 from bpfbox.dsl import PolicyGenerator
 from pprint import pprint
 
-parser = PolicyGenerator(None)
+parser = PolicyGenerator()
 
 def test_macro_smoke():
     macro = parser._macro()

--- a/tests/policy/test_policy_generation.py
+++ b/tests/policy/test_policy_generation.py
@@ -49,7 +49,7 @@ def setup_testdir():
 
 @pytest.fixture
 def policy_generator(bpf_program: BPFProgram):
-    yield PolicyGenerator(bpf_program)
+    yield PolicyGenerator()
 
 
 def test_open_complex_policy_no_execute_permission(policy_generator: PolicyGenerator, setup_testdir):


### PR DESCRIPTION
Now, the DSL policy generator depends only on libbpfbox commands